### PR TITLE
support for MacOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/shoenig/offheap
 go 1.18
 
 require (
+	github.com/edsrzf/mmap-go v1.1.0
 	github.com/shoenig/test v0.6.6
-	github.com/tysonmote/gommap v0.0.2
 )
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require (
+	github.com/google/go-cmp v0.5.9 // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/shoenig/test v0.6.6 h1:Oe8TPH9wAbv++YPNDKJWUnI8Q4PPWCx3UbOfH+FxiMU=
 github.com/shoenig/test v0.6.6/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-github.com/tysonmote/gommap v0.0.2 h1:TNTjXaXxiLWuWVTU9BfSb1bAEvfrptf8m5+N3LyTd6Q=
-github.com/tysonmote/gommap v0.0.2/go.mod h1:zZKhSp7mLDDzdl8MHbaDEJ3PH9VibPlFXV1t+4wmC00=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/offheap.go
+++ b/offheap.go
@@ -6,7 +6,7 @@
 package offheap
 
 import (
-	"github.com/tysonmote/gommap"
+	"github.com/edsrzf/mmap-go"
 )
 
 // Memory represents a private anonymous mmap in-memory-only
@@ -17,12 +17,12 @@ type Memory []byte
 
 // New creates an offheap Memory slice of the specified number of bytes.
 func New(bytes int64) (Memory, error) {
-	mapped, e := gommap.MapRegion(
+	mapped, e := mmap.MapRegion(
+		nil,
+		int(bytes),
+		mmap.COPY,
+		mmap.ANON,
 		0,
-		0,
-		bytes,
-		gommap.PROT_READ|gommap.PROT_WRITE,
-		gommap.MAP_ANONYMOUS|gommap.MAP_PRIVATE,
 	)
 
 	if e != nil {
@@ -34,5 +34,6 @@ func New(bytes int64) (Memory, error) {
 // Unmap will delete the offheap Memory slice. Any usage of the Memory
 // afterwords will cause a panic.
 func (m Memory) Unmap() error {
-	return gommap.MMap(m).UnsafeUnmap()
+	p := mmap.MMap(m)
+	return p.Unmap()
 }


### PR DESCRIPTION
The library currently doesn't work on MacOS with `operation not supported by device`:

```
$ go test
--- FAIL: Test_New (0.00s)
    assert.go:11: 
        offheap_test.go:11: expected nil error
        ↪ error: operation not supported by device
--- FAIL: Test_Unmap (0.00s)
    assert.go:11: 
        offheap_test.go:17: expected nil error
        ↪ error: operation not supported by device
FAIL
exit status 1
FAIL	github.com/shoenig/offheap	0.953s
```

This occurs because `MAP_ANONYMOUS` has a different constant value between Linux and MacOS \[[ref](https://github.com/rust-lang/libc/issues/1060#issuecomment-429624061)\], and `tysonmote/gommap` uses the same constant values for every Unix-like.

This patch migrates the `mmap`ing library to `edsrzf/mmap-go` which doesn't have the same problem. I considered sending a patch to `tysonmote/gommap` but it doesn't seem trivial given its architecture of obtaining the constants.